### PR TITLE
Add GPU support for AMD and NVIDIA

### DIFF
--- a/ollama/README.md
+++ b/ollama/README.md
@@ -15,3 +15,27 @@ To integrate with the default [Ollama](https://www.home-assistant.io/integration
 ## Note
 
 By default the container runs with CPU acceleration only. If you are interesting in getting GPU support, please check the [Website of the Ollama Container Image](https://hub.docker.com/r/ollama/ollama).
+
+## Enabling NVIDIA GPU Support
+
+To enable NVIDIA GPU support, ensure that the following device mappings are included in the `ollama/config.yaml` file:
+
+```yaml
+devices:
+  - /dev/nvidia0:/dev/nvidia0
+  - /dev/nvidiactl:/dev/nvidiactl
+  - /dev/nvidia-uvm:/dev/nvidia-uvm
+  - /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools
+```
+
+## Enabling AMD GPU Support
+
+To enable AMD GPU support, ensure that the following device mappings are included in the `ollama/config.yaml` file:
+
+```yaml
+devices:
+  - /dev/kfd:/dev/kfd
+  - /dev/dri:/dev/dri
+```
+
+Additionally, you need to install the ROCm and AMDGPU-PRO drivers for AMD GPU support.

--- a/ollama/config.yaml
+++ b/ollama/config.yaml
@@ -27,5 +27,9 @@ watchdog: tcp://[HOST]:[PORT:11434]
 devices:
   - /dev/kfd:/dev/kfd
   - /dev/dri:/dev/dri
+  - /dev/nvidia0:/dev/nvidia0
+  - /dev/nvidiactl:/dev/nvidiactl
+  - /dev/nvidia-uvm:/dev/nvidia-uvm
+  - /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools
 volumes:
   - ollama:/root/.ollama


### PR DESCRIPTION
Add support for NVIDIA and AMD GPUs in the Docker configuration and update documentation.

* **Configuration Changes:**
  - Add device mappings for NVIDIA GPUs in `ollama/config.yaml`:
    - `/dev/nvidia0:/dev/nvidia0`
    - `/dev/nvidiactl:/dev/nvidiactl`
    - `/dev/nvidia-uvm:/dev/nvidia-uvm`
    - `/dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools`
  - Retain existing device mappings for AMD GPUs:
    - `/dev/kfd:/dev/kfd`
    - `/dev/dri:/dev/dri`

* **Documentation Updates:**
  - Add instructions for enabling NVIDIA GPU support in `ollama/README.md`.
  - Add instructions for enabling AMD GPU support in `ollama/README.md`.
  - Mention the need to install ROCm and AMDGPU-PRO drivers for AMD GPU support.

