### PR TITLE
Fix deprecated devices format in add-on config

### DIFF
--- a/ollama/README.md
+++ b/ollama/README.md
@@ -22,10 +22,10 @@ To enable NVIDIA GPU support, ensure that the following device mappings are incl
 
 ```yaml
 devices:
-  - /dev/nvidia0:/dev/nvidia0
-  - /dev/nvidiactl:/dev/nvidiactl
-  - /dev/nvidia-uvm:/dev/nvidia-uvm
-  - /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools
+  - /dev/nvidia0
+  - /dev/nvidiactl
+  - /dev/nvidia-uvm
+  - /dev/nvidia-uvm-tools
 ```
 
 ## Enabling AMD GPU Support
@@ -34,8 +34,8 @@ To enable AMD GPU support, ensure that the following device mappings are include
 
 ```yaml
 devices:
-  - /dev/kfd:/dev/kfd
-  - /dev/dri:/dev/dri
+  - /dev/kfd
+  - /dev/dri
 ```
 
 Additionally, you need to install the ROCm and AMDGPU-PRO drivers for AMD GPU support.

--- a/ollama/config.yaml
+++ b/ollama/config.yaml
@@ -25,12 +25,7 @@ ports_description:
 startup: application
 watchdog: tcp://[HOST]:[PORT:11434]
 devices:
-  - /dev/kfd:/dev/kfd
-  - /dev/dri:/dev/dri
-  # Commenting out potentially problematic device lines
-  # - /dev/nvidia0:/dev/nvidia0
-  # - /dev/nvidiactl:/dev/nvidiactl
-  # - /dev/nvidia-uvm:/dev/nvidia-uvm
-  # - /dev/nvidia-uvm-tools:/dev/nvidia-uvm-tools
+  - /dev/kfd
+  - /dev/dri
 volumes:
   - ollama:/root/.ollama


### PR DESCRIPTION
Update the `devices` section in `ollama/config.yaml` to use the new format with a list of paths.

* Change the `devices` section to:
  ```yaml
  devices:
    - /dev/kfd
    - /dev/dri
  ```

* Update `ollama/README.md` to reflect the new format for enabling NVIDIA and AMD GPU support.
  - Change the device mappings for NVIDIA GPU support to a list of paths.
  - Change the device mappings for AMD GPU support to a list of paths.

